### PR TITLE
First pass at correcting issue #17

### DIFF
--- a/flatpack/src/main/java/net/sf/flatpack/util/ParserUtils.java
+++ b/flatpack/src/main/java/net/sf/flatpack/util/ParserUtils.java
@@ -464,7 +464,24 @@ public final class ParserUtils {
                 // remember we are working are way backwards on the line
                 if (qualiFound) {
                     if (chrArry[i] == delimiter) {
-                        return true;
+                        // before deciding if this is the begining of a qualified new line
+                        // I think we have to go back to the beginning of the line and see if we are inside a qualified
+                        // field or not?
+                        //return true;
+                        boolean qualifiedContent = chrArry[0] == qualifier;
+                        for(int index = 0; index < chrArry.length; index++) {
+                            char currentChar = chrArry[index];
+                            qualifiedContent = currentChar == qualifier;
+                            if(qualifiedContent) {
+                                // go until first occurence of closing qualifierdelimiter combination
+                                for(; index < chrArry.length; index++) {
+                                    if(chrArry[index] == delimiter && chrArry[++index] == qualifier) {
+                                        qualifiedContent = false;
+                                    }
+                                }
+                            }
+                        }
+                        return qualifiedContent;
                     }
                     // guard against multiple qualifiers in the sequence [ ,""We ]
                     qualiFound = chrArry[i] == qualifier;
@@ -501,7 +518,24 @@ public final class ParserUtils {
                     continue;
                 }
                 if (chrArry[i] == delimiter) {
-                    return true;
+                        // before deciding if this is the begining of a qualified new line
+                        // I think we have to go back to the beginning of the line and see if we are inside a qualified
+                        // field or not?
+                        //return true;
+                        boolean qualifiedContent = chrArry[0] == qualifier;
+                        for(int index = 0; index < chrArry.length; index++) {
+                            char currentChar = chrArry[index];
+                            qualifiedContent = currentChar == qualifier;
+                            if(qualifiedContent) {
+                                // go until first occurence of closing qualifierdelimiter combination
+                                for(; index < chrArry.length; index++) {
+                                    if(chrArry[index] == delimiter && chrArry[++index] == qualifier) {
+                                        qualifiedContent = false;
+                                    }
+                                }
+                            }
+                        }
+                        return qualifiedContent;
                 }
                 break;
             }

--- a/flatpack/src/test/java/net/sf/flatpack/parserutils/ParserUtilsTest.java
+++ b/flatpack/src/test/java/net/sf/flatpack/parserutils/ParserUtilsTest.java
@@ -63,6 +63,29 @@ public class ParserUtilsTest extends TestCase {
         assertEquals("list should be empty and is not...", ParserUtils.isListElementsEmpty(l), true);
     }
 
+    public void testQualifiedNonMultiLine() {
+        final String data = "data 1-1,data 1-2,\"qualified,data 1-3,\"\n";
+         assertEquals(ParserUtils.isMultiLine(data.toCharArray(), ',', '\"'), false);
+    }
+
+    public void testQualifiedMultiLine() {
+        final String data = "data 1-1,data 1-2,\"qualified,data 1-3,\n" +
+                            "qualified data 1-3 continued from previous line\"\n";
+         assertEquals(ParserUtils.isMultiLine(data.toCharArray(), ',', '\"'), true);
+    }
+
+    public void testNonQualifiedNonMultiLine() {
+        final String data = "data 1-1,data 1-2,qualified,data 1-3\n";
+         assertEquals(ParserUtils.isMultiLine(data.toCharArray(), ',', '\"'), false);
+    }
+
+    public void testNonQualifiedMultiLine() {
+        // can't really have multiline without qualifier
+        final String data = "data 1-1,data 1-2,qualified,data 1-3\n" +
+                            "qualified data 1-3 continued from previous line\n";
+         assertEquals(ParserUtils.isMultiLine(data.toCharArray(), ',', '\"'), false);
+    }
+
     public static void main(final String[] args) {
         junit.textui.TestRunner.run(ParserUtilsTest.class);
     }


### PR DESCRIPTION
In a delimited, qualified file, if the last field of a line is qualified and the last character in the field content is the delimiter, the delimiterqualifier pair is mistaken for the start of a new multiline field.

To avoid this I think the line must be parsed from the beginning to confirm the content at the end is or is not within a qualified field.

I have added what I think to be correct logic for this in ParerUtils.isMultiline and tests to prove the changes in ParserUtils.
